### PR TITLE
Fix C# API for MLAPI_SetLedColors and _availableLEDs initialization

### DIFF
--- a/LightController/ControlBase/LightApiDLL.cs
+++ b/LightController/ControlBase/LightApiDLL.cs
@@ -134,10 +134,10 @@ namespace MysticLightController
         public static extern int MLAPI_SetLedColors(
             [In, MarshalAs(UnmanagedType.BStr)] string type,
             [In, MarshalAs(UnmanagedType.U4)] uint index,
-            [MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_BSTR)] ref String[] ledName,
-            [MarshalAs(UnmanagedType.U4)] ref uint R,
-            [MarshalAs(UnmanagedType.U4)] ref uint G,
-            [MarshalAs(UnmanagedType.U4)] ref uint B
+            [In, MarshalAs(UnmanagedType.SafeArray, SafeArraySubType = VarEnum.VT_BSTR)] ref String[] ledName,
+            [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] R,
+            [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] G,
+            [In, MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.U4)] uint[] B
         );
 
         [DllImport(SDK_NAME, CallingConvention = CallingConvention.Cdecl, CharSet = CharSet.Ansi)]

--- a/LightController/ControlBase/LightController.cs
+++ b/LightController/ControlBase/LightController.cs
@@ -60,9 +60,11 @@ namespace MysticLightController
                 uint ledAmount = UInt32.Parse(ledCount[i]);
                 if (ledAmount == 0)
                     continue;
-                
+
+                List<LED> leds = new List<LED>();
                 for(uint ledIndex = 0; ledIndex < ledAmount; ledIndex++)
-                    _availableLEDs[device].Append(new LED(device, ledIndex));
+                    leds.Add(new LED(device, ledIndex));
+                _availableLEDs.Add(device, leds.ToArray());
             }
         }
 


### PR DESCRIPTION
Update the C# definition for the `MLAPI_SetLedColors` API function.
```c
/**
 * MLAPI_SetLedColors
 * Sets the colors for multiple LEDs within a given LED area simultaneously. The function MLAPI_GetLedName
 *   returns an array of LED names of the format "<area index>:<LED name>". The <area index> is used as the argument index
 *   for the index parameter. The <LED name> is used as one or more of the names in the ledName array parameter.
 *
 * @param type The device name
 * @param index The Area Index for the LEDs being modified
 * @param ledName An array of LED names to set the colors for. Must belong to the same LED Area
 * @param R An array of uints representing the Red component color for each of the named LEDs
 * @param G An array of uints representing the Green component color for each of the named LEDs
 * @param B An array of uints representing the Blue component color for each of the named LEDs
 */
```

Also updates the initialization for the `_availableLEDs` dictionary so as to operate successfully.